### PR TITLE
remove the cwe allow list dependency.

### DIFF
--- a/boostsec/converter/sarif/mobsfscan_sast.py
+++ b/boostsec/converter/sarif/mobsfscan_sast.py
@@ -1,5 +1,5 @@
 """Boost SAST extensions."""
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from .base import (
     ReportingDescriptor,
@@ -20,190 +20,11 @@ class MobsfscanCweType(TypedDict):
     """Represents a typed dict for a given CWE."""
 
     cwe_id: str
-    cwe_title: str
     severity: BoostFindingSeverity
     confidence: BoostFindingConfidence
 
 
-DEFAULT_RULE = MobsfscanCweType(
-    confidence=BoostFindingConfidence.NOT_SET,
-    cwe_id="CWE-UNKNOWN",
-    cwe_title="CWE-UNKNOWN - Original rule did not map to a known rule",
-    severity=BoostFindingSeverity.NOT_SET,
-)
-
-DEFAULT_RULE_KEY = DEFAULT_RULE.get("cwe_id")
-assert DEFAULT_RULE_KEY  # noqa S101 # type hint
-
-CWE_ALLOW_LIST: dict[str, MobsfscanCweType] = {
-    "CWE-73": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-73",
-        "cwe_title": "CWE-73 - External Control of File Name or Path",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-78": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-78",
-        "cwe_title": "CWE-78 - Improper Neutralization of Special "
-        "Elements used in an OS Command ('OS Command "
-        "Injection')",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-95": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-95",
-        "cwe_title": "CWE-95 - Improper Neutralization of Directives in "
-        "Dynamically Evaluated Code ('Eval Injection')",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-200": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-200",
-        "cwe_title": "CWE-200 - Exposure of Sensitive Information to "
-        "an Unauthorized Actor",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-276": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-276",
-        "cwe_title": "CWE-276 - Incorrect Default Permissions",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-295": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-295",
-        "cwe_title": "CWE-295 - Improper Certificate Validation",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-311": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-311",
-        "cwe_title": "CWE-311 - Missing Encryption of Sensitive Data",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-312": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-312",
-        "cwe_title": "CWE-312 - Cleartext Storage of Sensitive Information",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-321": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-321",
-        "cwe_title": "CWE-321 - Use of Hard-coded Cryptographic Key",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-326": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-326",
-        "cwe_title": "CWE-326 - Inadequate Encryption Strength",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-327": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-327",
-        "cwe_title": "CWE-327 - Use of a Broken or Risky Cryptographic "
-        "Algorithm",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-329": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-329",
-        "cwe_title": "CWE-329 - Generation of Predictable IV with CBC Mode",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-330": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-330",
-        "cwe_title": "CWE-330 - Use of Insufficiently Random Values",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-353": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-353",
-        "cwe_title": "CWE-353 - Missing Support for Integrity Check",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-489": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-489",
-        "cwe_title": "CWE-489 - Active Debug Code",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-502": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-502",
-        "cwe_title": "CWE-502 - Deserialization of Untrusted Data",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-532": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-532",
-        "cwe_title": "CWE-532 - Insertion of Sensitive Information "
-        "into Log File",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-611": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-611",
-        "cwe_title": "CWE-611 - Improper Restriction of XML External "
-        "Entity Reference",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-649": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-649",
-        "cwe_title": "CWE-649 - Reliance on Obfuscation or Encryption "
-        "of Security-Relevant Inputs without Integrity Checking",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-676": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-676",
-        "cwe_title": "CWE-676 - Use of Potentially Dangerous Function",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-749": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-749",
-        "cwe_title": "CWE-749 - Exposed Dangerous Method or Function",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-757": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-757",
-        "cwe_title": "CWE-757 - Selection of Less-Secure Algorithm "
-        "During Negotiation ('Algorithm Downgrade')",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-780": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-780",
-        "cwe_title": "CWE-780 - Use of RSA Algorithm without OAEP",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-798": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-798",
-        "cwe_title": "CWE-798 - Use of Hard-coded Credentials",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-919": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-919",
-        "cwe_title": "CWE-919 - Weaknesses in Mobile Applications",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    "CWE-1204": {
-        "confidence": BoostFindingConfidence.NOT_SET,
-        "cwe_id": "CWE-1204",
-        "cwe_title": "CWE-1204 - Generation of Weak Initialization "
-        "Vector (IV)",
-        "severity": BoostFindingSeverity.NOT_SET,
-    },
-    DEFAULT_RULE_KEY: DEFAULT_RULE,
-}
+UNKNOWN_CWE_ID: str = "CWE-UNKNOWN"
 
 
 class MobsfscanCweSastTaxa:
@@ -226,11 +47,15 @@ class MobsfscanCweSastTaxa:
         return self.cwe["cwe_id"] == other.cwe["cwe_id"]
 
     @classmethod
-    def find_taxa_by_cwe_id(cls, cwe_id: Optional[str]) -> "MobsfscanCweSastTaxa":
+    def find_taxa_by_cwe_id(cls, cwe_id: str) -> "MobsfscanCweSastTaxa":
         """Return a taxa based on the CWE id."""
-        cwe_id = cwe_id or ""
-        cwe = CWE_ALLOW_LIST.get(cwe_id, DEFAULT_RULE)
-        return cls(cwe)
+        return cls(
+            cwe={
+                "cwe_id": cwe_id,
+                "severity": BoostFindingSeverity.NOT_SET,
+                "confidence": BoostFindingConfidence.NOT_SET,
+            }
+        )
 
     def as_reference(self) -> ReportingDescriptorReference:
         """Return as ReportingDescriptorReference."""

--- a/tests/unit/cli/commands/test_process.py
+++ b/tests/unit/cli/commands/test_process.py
@@ -23,7 +23,7 @@ from boostsec.converter.sarif.base import (
 )
 from boostsec.converter.sarif.mobsfscan_sast import (
     BOOST_SAST_TAXONOMY_NAME,
-    DEFAULT_RULE_KEY,
+    UNKNOWN_CWE_ID,
 )
 
 SnykDataT = dict[str, Any]
@@ -189,9 +189,9 @@ def test_cleanup(report: ReportingDescriptor) -> None:
             ],
             "CWE-915",
         ),
-        (["OWASP-A1: Injection"], DEFAULT_RULE_KEY),
-        ([], DEFAULT_RULE_KEY),
-        (None, DEFAULT_RULE_KEY),
+        (["OWASP-A1: Injection"], UNKNOWN_CWE_ID),
+        ([], UNKNOWN_CWE_ID),
+        (None, UNKNOWN_CWE_ID),
     ],
 )
 def test_memoize_cwe_for_rule(
@@ -202,7 +202,7 @@ def test_memoize_cwe_for_rule(
         id=faker.pystr(),
         properties=PropertyBag(tags=tags) if tags else None,
     )
-    memo: dict[str, Optional[str]] = {}
+    memo: dict[str, str] = {}
 
     memoize_cwe_for_rule(rule, memo)
 

--- a/tests/unit/sarif/test_mobsfscan_sast.py
+++ b/tests/unit/sarif/test_mobsfscan_sast.py
@@ -11,9 +11,7 @@ from boostsec.converter.sarif.boostsec import (
 )
 from boostsec.converter.sarif.mobsfscan_sast import (
     BOOST_SAST_TAXONOMY_NAME,
-    CWE_ALLOW_LIST,
-    DEFAULT_RULE,
-    DEFAULT_RULE_KEY,
+    UNKNOWN_CWE_ID,
     MobsfscanCweSastTaxa,
     MobsfscanCweType,
 )
@@ -26,14 +24,28 @@ faker = Faker()
     [
         (
             "CWE-22",
-            CWE_ALLOW_LIST.get("CWE-22"),
+            {
+                "cwe_id": "CWE-22",
+                "confidence": BoostFindingConfidence.NOT_SET,
+                "severity": BoostFindingSeverity.NOT_SET,
+            },
         ),
         (
             "kartoffel",
-            DEFAULT_RULE,
+            {
+                "cwe_id": "kartoffel",
+                "confidence": BoostFindingConfidence.NOT_SET,
+                "severity": BoostFindingSeverity.NOT_SET,
+            },
         ),
-        (DEFAULT_RULE_KEY, DEFAULT_RULE),
-        (None, DEFAULT_RULE),
+        (
+            UNKNOWN_CWE_ID,
+            {
+                "cwe_id": UNKNOWN_CWE_ID,
+                "confidence": BoostFindingConfidence.NOT_SET,
+                "severity": BoostFindingSeverity.NOT_SET,
+            },
+        ),
     ],
 )
 def test_find_taxa_by_cwe_id(cwe_id: str, expected: MobsfscanCweType) -> None:
@@ -108,9 +120,8 @@ def test_equality_not_implemented() -> None:
 def _mobsfscan_cwe_sast_taxa_factory() -> MobsfscanCweSastTaxa:
     return MobsfscanCweSastTaxa(
         cwe=MobsfscanCweType(
-            confidence=random.choice(list(BoostFindingConfidence)),
             cwe_id=faker.pystr(),
-            cwe_title=faker.pystr(),
             severity=random.choice(list(BoostFindingSeverity)),
+            confidence=random.choice(list(BoostFindingConfidence)),
         )
     )


### PR DESCRIPTION
removes the need for allowed list and only send the default cwe id when the rule raised by the scanner doesn't advertize a cwe for the triggered rules.